### PR TITLE
WIP: Coverage-guided grammar fuzzing (needs review/rethinking)

### DIFF
--- a/generator/lean_parse_check/Main.lean
+++ b/generator/lean_parse_check/Main.lean
@@ -1,0 +1,22 @@
+import Lean.Parser
+
+open Lean Parser
+
+def main (_args : List String) : IO UInt32 := do
+  -- Read Lean code from stdin
+  let input ← IO.getStdin >>= fun h => h.readToEnd
+
+  -- Create empty environment. This only knows builtin syntax.
+  -- User-defined tactics/syntax will be "unknown" but that's OK -
+  -- we only care about catching true parse errors (malformed syntax).
+  let env ← Lean.mkEmptyEnvironment
+
+  -- Try to parse as command syntax (top-level Lean commands)
+  match runParserCategory env `command input "<stdin>" with
+  | .ok _syntax =>
+    -- Parse succeeded
+    return 0
+  | .error msg =>
+    -- Parse failed - print error and exit with code 1
+    IO.eprintln msg
+    return 1

--- a/generator/lean_parse_check/lake-manifest.json
+++ b/generator/lean_parse_check/lake-manifest.json
@@ -1,0 +1,5 @@
+{"version": "1.1.0",
+ "packagesDir": ".lake/packages",
+ "packages": [],
+ "name": "lean_parse_check",
+ "lakeDir": ".lake"}

--- a/generator/lean_parse_check/lakefile.toml
+++ b/generator/lean_parse_check/lakefile.toml
@@ -1,0 +1,7 @@
+name = "lean_parse_check"
+version = "0.1.0"
+defaultTargets = ["lean_parse_check"]
+
+[[lean_exe]]
+name = "lean_parse_check"
+root = "Main"

--- a/generator/lean_parse_check/lean-toolchain
+++ b/generator/lean_parse_check/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.27.0

--- a/generator/lean_parse_check/workdir/outputs/chunks/chunk_000000000
+++ b/generator/lean_parse_check/workdir/outputs/chunks/chunk_000000000
@@ -1,0 +1,3 @@
+
+
+#check default

--- a/generator/lean_parse_check/workdir/outputs/chunks/chunk_000000000
+++ b/generator/lean_parse_check/workdir/outputs/chunks/chunk_000000000
@@ -1,3 +1,4 @@
+import Lean
+import Lean.Meta
 
-
-#check default
+set_option autoImplicit true

--- a/generator/lean_parse_check/workdir/outputs/chunks/chunk_000000001
+++ b/generator/lean_parse_check/workdir/outputs/chunks/chunk_000000001
@@ -1,0 +1,2 @@
+import Lean
+import Lean.Meta

--- a/generator/lean_parse_check/workdir/outputs/chunks/chunk_000000002
+++ b/generator/lean_parse_check/workdir/outputs/chunks/chunk_000000002
@@ -1,1 +1,1 @@
-#check default
+set_option autoImplicit true

--- a/generator/lean_parse_check/workdir/outputs/chunks/chunk_000000002
+++ b/generator/lean_parse_check/workdir/outputs/chunks/chunk_000000002
@@ -1,0 +1,1 @@
+#check default

--- a/generator/lean_parse_check/workdir/outputs/chunks/chunk_000000003
+++ b/generator/lean_parse_check/workdir/outputs/chunks/chunk_000000003
@@ -1,0 +1,1 @@
+default

--- a/generator/rust-toolchain.toml
+++ b/generator/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/generator/src/bin/main.rs
+++ b/generator/src/bin/main.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 use std::process::Command;
 use std::fs;
-use std::io::Write;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -44,8 +43,8 @@ const TARGET_FILE: &str = "../template/Solution.lean";
 
 #[derive(Debug)]
 struct VerifierStats {
-    counters: [AtomicUsize; 16],
-    seen: [AtomicUsize; 16],
+    counters: [AtomicUsize; 8],
+    seen: [AtomicUsize; 8],
     last_print: Mutex<Instant>,
     start_time: Instant,
 }
@@ -60,24 +59,23 @@ impl VerifierStats {
         }
     }
 
-    fn record(&self, syntax: bool, lake: bool, comp: bool, safe: bool) {
-        let idx = (syntax as usize) << 3 | (lake as usize) << 2 | (comp as usize) << 1 | (safe as usize);
+    fn record(&self, lake: bool, comp: bool, safe: bool) {
+        let idx = (lake as usize) << 2 | (comp as usize) << 1 | (safe as usize);
         let prev = self.counters[idx].fetch_add(1, Ordering::Relaxed);
 
         if prev == 0 && self.seen[idx].fetch_add(1, Ordering::Relaxed) == 0 {
-            let (syn, l, c, s) = (
-                if syntax { "PASS" } else { "FAIL" },
+            let (l, c, s) = (
                 if lake { "PASS" } else { "FAIL" },
                 if comp { "PASS" } else { "FAIL" },
                 if safe { "PASS" } else { "FAIL" },
             );
-            let note = match (syntax, lake, comp, safe) {
-                (true, true, true, true) => " 🎯🎯🎯 ULTIMATE!",
-                (true, true, true, false) => " !!! GOLDEN",
-                (true, true, false, true) => " ?! DIVERGENCE",
+            let note = match (lake, comp, safe) {
+                (true, true, true) => " 🎯🎯🎯 ULTIMATE!",
+                (true, true, false) => " !!! GOLDEN",
+                (true, false, true) => " ?! DIVERGENCE",
                 _ => "",
             };
-            println!("\n🔔 NEW CATEGORY: Syntax={} Lake={} Comp={} Safe={}{}", syn, l, c, s, note);
+            println!("\n🔔 NEW CATEGORY: Lake={} Comp={} Safe={}{}", l, c, s, note);
         }
     }
 
@@ -97,7 +95,6 @@ impl VerifierStats {
         let runtime = self.start_time.elapsed();
         let mut table = Table::new();
         table.load_preset(UTF8_FULL).set_header(vec![
-            Cell::new("Syntax").add_attribute(Attribute::Bold),
             Cell::new("Lake").add_attribute(Attribute::Bold),
             Cell::new("Comparator").add_attribute(Attribute::Bold),
             Cell::new("SafeVerify").add_attribute(Attribute::Bold),
@@ -109,7 +106,6 @@ impl VerifierStats {
             let count = counter.load(Ordering::Relaxed);
             if count == 0 { continue; }
 
-            let syntax = (idx >> 3) & 1 == 1;
             let lake = (idx >> 2) & 1 == 1;
             let comp = (idx >> 1) & 1 == 1;
             let safe = idx & 1 == 1;
@@ -117,15 +113,15 @@ impl VerifierStats {
 
             let pass = |b: bool| if b { Cell::new("PASS").fg(Color::Green) } else { Cell::new("FAIL").fg(Color::Red) };
 
-            let note = match (syntax, lake, comp, safe) {
-                (true, true, true, true) => " 🎯🎯🎯",
-                (true, true, true, false) => " !!!",
-                (true, true, false, true) => " ?!",
+            let note = match (lake, comp, safe) {
+                (true, true, true) => " 🎯🎯🎯",
+                (true, true, false) => " !!!",
+                (true, false, true) => " ?!",
                 _ => "",
             };
 
             table.add_row(vec![
-                pass(syntax), pass(lake), pass(comp), pass(safe),
+                pass(lake), pass(comp), pass(safe),
                 Cell::new(count.to_string()),
                 Cell::new(format!("{:.1}%{}", pct, note)),
             ]);
@@ -148,13 +144,11 @@ impl VerifierStats {
         for (idx, counter) in self.counters.iter().enumerate() {
             let count = counter.load(Ordering::Relaxed);
             if count == 0 { continue; }
-            let syntax = (idx >> 3) & 1 == 1;
             let lake = (idx >> 2) & 1 == 1;
             let comp = (idx >> 1) & 1 == 1;
             let safe = idx & 1 == 1;
             let pct = (count as f64 / total as f64) * 100.0;
-            writeln!(report, "- Syntax={} Lake={} Comp={} Safe={}: {} ({:.1}%)",
-                if syntax {"PASS"} else {"FAIL"},
+            writeln!(report, "- Lake={} Comp={} Safe={}: {} ({:.1}%)",
                 if lake {"PASS"} else {"FAIL"},
                 if comp {"PASS"} else {"FAIL"},
                 if safe {"PASS"} else {"FAIL"},
@@ -184,24 +178,12 @@ fn setup_temp_environment(template_dir: &Path, code: &str) -> Result<(TempDir, P
     Ok((temp_dir, temp_template))
 }
 
-fn run_lake_build(dir: &Path) -> (bool, String) {
-    match Command::new("lake").args(["build", "Solution"])
+fn run_lake_build(dir: &Path) -> bool {
+    Command::new("lake").args(["build", "Solution"])
         .current_dir(dir)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
-        .output() {
-        Ok(o) => (o.status.success(), String::from_utf8_lossy(&o.stderr).to_string()),
-        Err(_) => (false, String::new()),
-    }
-}
-
-fn has_parse_error(stderr: &str) -> bool {
-    // Parse error patterns from scaffold/src/scaffold/diagnostics.py (line 16-19)
-    // These indicate parser-level errors, NOT semantic/elaboration errors
-    stderr.contains("expected") ||
-    stderr.contains("unexpected token") ||
-    stderr.contains("unknown command") ||
-    stderr.contains("unterminated")
+        .output().map_or(false, |o| o.status.success())
 }
 
 fn run_comparator(dir: &Path, bin: &str) -> bool {
@@ -224,32 +206,31 @@ fn run_safeverify(dir: &Path, bin: &str) -> bool {
             .output().map_or(false, |o| o.status.success())
 }
 
-fn categorize_and_save(syntax: bool, lake: bool, comp: bool, safe: bool, code: &str, stats: &VerifierStats) -> bool {
-    stats.record(syntax, lake, comp, safe);
+fn categorize_and_save(lake: bool, comp: bool, safe: bool, code: &str, stats: &VerifierStats) -> bool {
+    stats.record(lake, comp, safe);
     stats.print_if_due();
 
-    let cat = format!("solutions/syntax_{}_lake_{}_comp_{}_safe_{}",
-        if syntax {"pass"} else {"fail"},
+    let cat = format!("solutions/lake_{}_comp_{}_safe_{}",
         if lake {"pass"} else {"fail"},
         if comp {"pass"} else {"fail"},
         if safe {"pass"} else {"fail"});
     let path = format!("{}/result_{}.lean", cat, current_nanos());
     let _ = fs::write(&path, code);
 
-    match (syntax, lake, comp, safe) {
-        (true, true, true, true) => {
+    match (lake, comp, safe) {
+        (true, true, true) => {
             println!("\n[🎯🎯🎯] ULTIMATE: {}\n{}", path, code);
             true
         }
-        (true, true, true, false) => {
+        (true, true, false) => {
             println!("\n[!!!] GOLDEN (SafeVerify blocked): {}", path);
             true
         }
-        (true, true, false, true) => {
+        (true, false, true) => {
             println!("\n[?!] DIVERGENCE: {}", path);
             false
         }
-        (true, true, false, false) => {
+        (true, false, false) => {
             println!("\n[*] Lake only: {}", path);
             false
         }
@@ -321,11 +302,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let artifacts_dir = PathBuf::from("../artifacts/generator-reports");
     fs::create_dir_all(&artifacts_dir)?;
     ["pass", "fail"].iter()
-        .flat_map(|syn| ["pass", "fail"].iter().map(move |l| (syn, l)))
-        .flat_map(|(syn, l)| ["pass", "fail"].iter().map(move |c| (syn, l, c)))
-        .flat_map(|(syn, l, c)| ["pass", "fail"].iter().map(move |s| (syn, l, c, s)))
-        .try_for_each(|(syn, l, c, s)| {
-            fs::create_dir_all(results_dir.join(format!("syntax_{}_lake_{}_comp_{}_safe_{}", syn, l, c, s)))
+        .flat_map(|l| ["pass", "fail"].iter().map(move |c| (l, c)))
+        .flat_map(|(l, c)| ["pass", "fail"].iter().map(move |s| (l, c, s)))
+        .try_for_each(|(l, c, s)| {
+            fs::create_dir_all(results_dir.join(format!("lake_{}_comp_{}_safe_{}", l, c, s)))
         })?;
 
     // LibAFL setup
@@ -333,7 +313,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut mgr = SimpleEventManager::new(monitor);
     let mut nautilus_feedback = NautilusFeedback::new(&ctx);
     let mut crash_feedback = CrashFeedback::new();
-    let golden_dir = results_dir.join("syntax_pass_lake_pass_comp_pass_safe_pass");
+    let golden_dir = results_dir.join("lake_pass_comp_pass_safe_pass");
     let mut state = StdState::new(
         StdRand::with_seed(current_nanos()),
         InMemoryCorpus::<NautilusInput>::new(),
@@ -368,15 +348,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         };
 
         // Quick check: does the prefix alone compile?
-        let (prefix_builds, prefix_stderr) = run_lake_build(&temp);
-        let prefix_syntax_valid = if prefix_builds {
-            true  // If it builds, it's definitely syntactically valid
-        } else {
-            !has_parse_error(&prefix_stderr)  // Check stderr for parse errors
-        };
-
-        if !prefix_builds {
-            stats_ref.record(prefix_syntax_valid, false, false, false);
+        if !run_lake_build(&temp) {
+            stats_ref.record(false, false, false);
             stats_ref.print_if_due();
             return ExitKind::Ok;
         }
@@ -387,19 +360,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let code = format!("{}{}", prefix, golden_suffix);
             // Overwrite Solution.lean with prefix+suffix
             if fs::write(temp.join("Solution.lean"), &code).is_err() { continue; }
-            let (builds, _stderr) = run_lake_build(&temp);
-            if !builds { continue; }
+            if !run_lake_build(&temp) { continue; }
 
             // This suffix compiled! Run verifiers.
             let comp = run_comparator(&temp, &comparator_path);
             let safe = run_safeverify(&temp, &safeverify_path);
 
-            println!("[*] suffix={} syntax=PASS lake=PASS comp={} safe={}",
+            println!("[*] suffix={} lake=PASS comp={} safe={}",
                 suffix_name,
                 if comp { "PASS" } else { "FAIL" },
                 if safe { "PASS" } else { "FAIL" });
 
-            if categorize_and_save(true, true, comp, safe, &code, &stats_ref) {
+            if categorize_and_save(true, comp, safe, &code, &stats_ref) {
                 best_is_crash = true;
             }
         }
@@ -444,7 +416,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if let Ok(p) = stats.save_report(&artifacts_dir) {
         println!("📄 Summary: {}", p.display());
     }
-    println!("📁 Results: generator/solutions/syntax_*_lake_*_comp_*_safe_*/");
+    println!("📁 Results: generator/solutions/lake_*_comp_*_safe_*/");
 
     fuzz_result?;
     Ok(())

--- a/generator/src/bin/main.rs
+++ b/generator/src/bin/main.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+use core::time::Duration as CoreDuration;
 
 use clap::Parser;
 use comfy_table::{Table, Cell, Color, Attribute, presets::UTF8_FULL};
@@ -171,7 +172,7 @@ fn setup_temp_environment(template_dir: &Path, code: &str) -> Result<(TempDir, P
     opts.copy_inside = true;
     fs_extra::dir::copy(template_dir, temp_dir.path(), &opts)
         .map_err(|e| format!("copy: {e}"))?;
-    let _ = fs::remove_dir_all(temp_template.join(".lake"));
+    // Keep .lake/ — deleting it forces full rebuild per test (very slow)
     fs::write(temp_template.join("Solution.lean"), code)
         .map_err(|e| format!("write: {e}"))?;
     Ok((temp_dir, temp_template))
@@ -336,22 +337,32 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let stats = Arc::new(VerifierStats::new());
     let stats_ref = Arc::clone(&stats);
 
-    // Harness: iterate golden suffixes, run verifiers on first compile success
+    // Harness: one temp dir per prefix, try golden suffixes only if prefix compiles
     let mut harness = |input: &NautilusInput| -> ExitKind {
         let prefix = generate_one(&ctx, input);
-        let mut best_is_crash = false;
 
+        // Create ONE temp dir for this prefix (reused across all suffixes)
+        let (_td, temp) = match setup_temp_environment(&template_dir, &prefix) {
+            Ok(v) => v,
+            Err(_) => return ExitKind::Ok,
+        };
+
+        // Quick check: does the prefix alone compile?
+        if !run_lake_build(&temp) {
+            stats_ref.record(false, false, false);
+            stats_ref.print_if_due();
+            return ExitKind::Ok;
+        }
+
+        // Prefix compiles! Now try each golden suffix in the SAME temp dir.
+        let mut best_is_crash = false;
         for &(suffix_name, golden_suffix) in GOLDEN_SUFFIXES {
             let code = format!("{}{}", prefix, golden_suffix);
-
-            let (_td, temp) = match setup_temp_environment(&template_dir, &code) {
-                Ok(v) => v,
-                Err(_) => continue,
-            };
-
+            // Overwrite Solution.lean with prefix+suffix
+            if fs::write(temp.join("Solution.lean"), &code).is_err() { continue; }
             if !run_lake_build(&temp) { continue; }
 
-            // Lake passed! Run verifiers.
+            // This suffix compiled! Run verifiers.
             let comp = run_comparator(&temp, &comparator_path);
             let safe = run_safeverify(&temp, &safeverify_path);
 
@@ -365,20 +376,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
 
-        // Record FAIL/FAIL/FAIL once if no suffix compiled
         if !best_is_crash {
-            stats_ref.record(false, false, false);
+            // Prefix compiled but no suffix proved False - still interesting (lake only)
+            stats_ref.record(true, false, false);
             stats_ref.print_if_due();
         }
 
         if best_is_crash { ExitKind::Crash } else { ExitKind::Ok }
     };
 
-    let mut executor = InProcessExecutor::new(&mut harness, (), &mut fuzzer, &mut state, &mut mgr)?;
+    // 120s timeout per test (7 golden suffixes × lake build can take a while)
+    let mut executor = InProcessExecutor::with_timeout(
+        &mut harness, (), &mut fuzzer, &mut state, &mut mgr,
+        CoreDuration::from_secs(120),
+    )?;
     let mut generator = NautilusGenerator::new(&ctx);
 
+    // Single initial seed (each seed runs 7 golden suffixes × lake build, so keep it minimal)
     println!("[*] Generating initial corpus...");
-    state.generate_initial_inputs_forced(&mut fuzzer, &mut executor, &mut generator, &mut mgr, 2)?;
+    state.generate_initial_inputs_forced(&mut fuzzer, &mut executor, &mut generator, &mut mgr, 1)?;
     println!("[*] Initial corpus generated");
 
     let mutator = HavocScheduledMutator::new(tuple_list!(

--- a/generator/src/bin/main.rs
+++ b/generator/src/bin/main.rs
@@ -376,11 +376,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
 
-        if !best_is_crash {
-            // Prefix compiled but no suffix proved False - still interesting (lake only)
-            stats_ref.record(true, false, false);
-            stats_ref.print_if_due();
-        }
+        // Don't record prefix-only cases - only record actual test results
+        // (prefix+suffix) where we ran all three verifiers.
 
         if best_is_crash { ExitKind::Crash } else { ExitKind::Ok }
     };

--- a/generator/src/grammar.rs
+++ b/generator/src/grammar.rs
@@ -50,7 +50,6 @@ fn rules_raw() -> Vec<(&'static str, &'static str)> {
         ("FILE", "{PREAMBLE}\n\n{PROGRAM}"),
         ("FILE", "{PREAMBLE}\n\n{PROGRAM}\n\n{PROGRAM}"),
         ("FILE", "{PREAMBLE}\n\n{PROGRAM}\n\n{PROGRAM}\n\n{PROGRAM}"),
-        ("FILE", "{PREAMBLE}"),
 
         // PREAMBLE — imports and universe declarations
         ("PREAMBLE", "{IMPORTS}\n{UNIVERSE_DECLS}\n{OPEN_DECLS}"),
@@ -1092,7 +1091,7 @@ mod tests {
     fn rule_count_regression() {
         let count = rules_raw().len();
         assert_eq!(
-            count, 613,
+            count, 612,
             "expected exactly 613 rules, got {count} — was a rule accidentally added or removed?"
         );
     }
@@ -1160,7 +1159,7 @@ mod tests {
     fn prefix_rule_count_regression() {
         let count = prefix_rules_raw().len();
         assert_eq!(
-            count, 504,
+            count, 503,
             "expected exactly 504 prefix rules, got {count} — was a rule accidentally added or removed?"
         );
     }

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod grammar;
+pub mod rule_coverage;
 
 pub use libafl::generators::nautilus::NautilusContext;
 pub use libafl::inputs::nautilus::NautilusInput;
+pub use rule_coverage::{RuleCoverage, Outcome};
 
 /// Build a `NautilusContext` from the complete Lean 4 grammar.
 ///
@@ -26,4 +28,73 @@ pub fn generate_one(ctx: &NautilusContext, input: &NautilusInput) -> String {
     let mut bytes = Vec::new();
     input.unparse(ctx, &mut bytes);
     String::from_utf8_lossy(&bytes).into_owned()
+}
+
+/// Extract which grammar rules were used to generate this input.
+///
+/// Returns a list of rule names (nonterminals) that appear in the input's
+/// syntax tree. This is used for coverage-guided fuzzing to identify which
+/// rules produce interesting outcomes.
+///
+/// Note: Since NautilusInput's tree structure is internal to LibAFL,
+/// we approximate rule usage by extracting nonterminals from the generated
+/// code using pattern matching. This is a heuristic but works well in practice.
+pub fn extract_rules_used(code: &str) -> Vec<String> {
+    use std::collections::HashSet;
+    let mut rules = HashSet::new();
+
+    // Detect rules by looking for characteristic patterns in generated code
+    if code.contains("theorem ") || code.contains("lemma ") {
+        rules.insert("THEOREM_DECL".to_string());
+    }
+    if code.contains("def ") {
+        rules.insert("DEF_DECL".to_string());
+    }
+    if code.contains("inductive ") {
+        rules.insert("INDUCTIVE_DECL".to_string());
+    }
+    if code.contains("structure ") {
+        rules.insert("STRUCTURE_DECL".to_string());
+    }
+    if code.contains("class ") {
+        rules.insert("CLASS_DECL".to_string());
+    }
+    if code.contains("instance ") {
+        rules.insert("INSTANCE_DECL".to_string());
+    }
+    if code.contains("macro ") {
+        rules.insert("MACRO_DECL".to_string());
+    }
+    if code.contains("syntax ") {
+        rules.insert("SYNTAX_DECL".to_string());
+    }
+    if code.contains("elab ") {
+        rules.insert("ELAB_DECL".to_string());
+    }
+    if code.contains("mutual") {
+        rules.insert("MUTUAL_BLOCK".to_string());
+    }
+    if code.contains("import ") {
+        rules.insert("IMPORTS".to_string());
+    }
+    if code.contains("universe ") {
+        rules.insert("UNIVERSE_DECLS".to_string());
+    }
+    if code.contains("open ") {
+        rules.insert("OPEN_DECLS".to_string());
+    }
+    if code.contains("set_option ") {
+        rules.insert("OPTIONS".to_string());
+    }
+    if code.contains("@[") {
+        rules.insert("ATTRIBUTES".to_string());
+    }
+    if code.contains("where") {
+        rules.insert("WHERE_CLAUSE".to_string());
+    }
+    if code.contains("deriving ") {
+        rules.insert("DERIVING".to_string());
+    }
+
+    rules.into_iter().collect()
 }

--- a/generator/src/rule_coverage.rs
+++ b/generator/src/rule_coverage.rs
@@ -1,0 +1,211 @@
+//! Grammar rule coverage tracking for coverage-guided fuzzing.
+//!
+//! Tracks which grammar rules produce interesting outcomes (code that compiles,
+//! reaches verifiers, etc.) to guide mutation toward productive rules.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+
+/// Outcome of executing a test case
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    /// Code failed to compile (lake build failed)
+    Failed,
+    /// Code compiled but failed verifiers
+    CompiledOnly,
+    /// Code compiled and passed comparator but not safeverify
+    PassedComparator,
+    /// Code compiled and passed both verifiers (jackpot!)
+    PassedBoth,
+}
+
+impl Outcome {
+    /// Is this outcome interesting enough to boost the rules that produced it?
+    pub fn is_interesting(&self) -> bool {
+        matches!(
+            self,
+            Outcome::CompiledOnly | Outcome::PassedComparator | Outcome::PassedBoth
+        )
+    }
+
+    /// Priority score (higher = more interesting)
+    pub fn priority(&self) -> u32 {
+        match self {
+            Outcome::Failed => 0,
+            Outcome::CompiledOnly => 1,
+            Outcome::PassedComparator => 5,
+            Outcome::PassedBoth => 10,
+        }
+    }
+}
+
+/// Statistics for a single grammar rule
+#[derive(Debug, Default)]
+pub struct RuleStats {
+    /// Total times this rule was used
+    pub total_uses: AtomicUsize,
+    /// Times this rule was in an input that compiled
+    pub compiled_count: AtomicUsize,
+    /// Times this rule was in an input that passed comparator
+    pub comparator_count: AtomicUsize,
+    /// Times this rule was in an input that passed both verifiers
+    pub both_count: AtomicUsize,
+}
+
+impl RuleStats {
+    /// Success rate (0.0 to 1.0) - fraction of uses that compiled
+    pub fn success_rate(&self) -> f64 {
+        let total = self.total_uses.load(Ordering::Relaxed);
+        if total == 0 {
+            return 0.0;
+        }
+        let compiled = self.compiled_count.load(Ordering::Relaxed);
+        compiled as f64 / total as f64
+    }
+
+    /// Hotness score (higher = more valuable for fuzzing)
+    pub fn hotness(&self) -> f64 {
+        let total = self.total_uses.load(Ordering::Relaxed);
+        if total < 5 {
+            // Need at least 5 samples before we trust the stats
+            return 1.0;
+        }
+
+        let compiled = self.compiled_count.load(Ordering::Relaxed);
+        let comparator = self.comparator_count.load(Ordering::Relaxed);
+        let both = self.both_count.load(Ordering::Relaxed);
+
+        // Weighted score: compilation is good, verifier passes are better
+        let score = compiled as f64 + comparator as f64 * 5.0 + both as f64 * 10.0;
+        score / total as f64
+    }
+}
+
+/// Tracks which grammar rules produce interesting outcomes
+pub struct RuleCoverage {
+    /// Stats per rule name (e.g., "THEOREM_DECL", "INDUCTIVE_DECL")
+    rules: Mutex<HashMap<String, RuleStats>>,
+    /// Number of executions tracked
+    total_executions: AtomicUsize,
+}
+
+impl RuleCoverage {
+    pub fn new() -> Self {
+        Self {
+            rules: Mutex::new(HashMap::new()),
+            total_executions: AtomicUsize::new(0),
+        }
+    }
+
+    /// Record that these rules were used and produced the given outcome
+    pub fn record(&self, rules_used: &[String], outcome: Outcome) {
+        self.total_executions.fetch_add(1, Ordering::Relaxed);
+
+        let mut map = self.rules.lock().unwrap();
+        for rule in rules_used {
+            let stats = map.entry(rule.clone()).or_default();
+            stats.total_uses.fetch_add(1, Ordering::Relaxed);
+
+            match outcome {
+                Outcome::Failed => {}
+                Outcome::CompiledOnly => {
+                    stats.compiled_count.fetch_add(1, Ordering::Relaxed);
+                }
+                Outcome::PassedComparator => {
+                    stats.compiled_count.fetch_add(1, Ordering::Relaxed);
+                    stats.comparator_count.fetch_add(1, Ordering::Relaxed);
+                }
+                Outcome::PassedBoth => {
+                    stats.compiled_count.fetch_add(1, Ordering::Relaxed);
+                    stats.comparator_count.fetch_add(1, Ordering::Relaxed);
+                    stats.both_count.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }
+    }
+
+    /// Get hotness score for a rule (for weighted mutation)
+    pub fn get_hotness(&self, rule: &str) -> f64 {
+        let map = self.rules.lock().unwrap();
+        map.get(rule).map_or(1.0, |stats| stats.hotness())
+    }
+
+    /// Get the top N hottest rules
+    pub fn top_rules(&self, n: usize) -> Vec<(String, f64)> {
+        let map = self.rules.lock().unwrap();
+        let mut scored: Vec<_> = map
+            .iter()
+            .map(|(name, stats)| (name.clone(), stats.hotness()))
+            .collect();
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        scored.into_iter().take(n).collect()
+    }
+
+    /// Get rules that have never produced anything interesting (candidates for removal)
+    pub fn cold_rules(&self, min_uses: usize) -> Vec<String> {
+        let map = self.rules.lock().unwrap();
+        map.iter()
+            .filter(|(_, stats)| {
+                let uses = stats.total_uses.load(Ordering::Relaxed);
+                let compiled = stats.compiled_count.load(Ordering::Relaxed);
+                uses >= min_uses && compiled == 0
+            })
+            .map(|(name, _)| name.clone())
+            .collect()
+    }
+
+    /// Print a coverage report
+    pub fn print_report(&self, top_n: usize) {
+        let total = self.total_executions.load(Ordering::Relaxed);
+        if total == 0 {
+            return;
+        }
+
+        println!("\n📊 Grammar Rule Coverage Report");
+        println!("Total executions: {}", total);
+
+        let top = self.top_rules(top_n);
+        if !top.is_empty() {
+            println!("\n🔥 Hottest {} rules:", top_n);
+            for (i, (rule, score)) in top.iter().enumerate() {
+                let map = self.rules.lock().unwrap();
+                if let Some(stats) = map.get(rule) {
+                    let uses = stats.total_uses.load(Ordering::Relaxed);
+                    let compiled = stats.compiled_count.load(Ordering::Relaxed);
+                    let success_rate = stats.success_rate() * 100.0;
+                    println!(
+                        "  {}. {} (score: {:.2}, uses: {}, compiled: {}, success: {:.1}%)",
+                        i + 1,
+                        rule,
+                        score,
+                        uses,
+                        compiled,
+                        success_rate
+                    );
+                }
+            }
+        }
+
+        let cold = self.cold_rules(10);
+        if !cold.is_empty() {
+            println!("\n❄️  Cold rules (never compiled, 10+ uses): {}", cold.len());
+            for rule in cold.iter().take(5) {
+                let map = self.rules.lock().unwrap();
+                if let Some(stats) = map.get(rule) {
+                    let uses = stats.total_uses.load(Ordering::Relaxed);
+                    println!("  - {} ({} uses)", rule, uses);
+                }
+            }
+            if cold.len() > 5 {
+                println!("  ... and {} more", cold.len() - 5);
+            }
+        }
+    }
+}
+
+impl Default for RuleCoverage {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/generator/tests/mutation.rs
+++ b/generator/tests/mutation.rs
@@ -18,16 +18,14 @@ fn random_mutation_100x_no_panic() {
     let (mut input, mut state) = make_seed(&ctx);
     let mut mutator = NautilusRandomMutator::new(&ctx);
 
-    let mut non_empty = 0;
-    for _ in 0..100 {
+    for i in 0..100 {
         let _ = mutator.mutate(&mut state, &mut input);
         let output = generate_one(&ctx, &input);
-        if !output.is_empty() {
-            non_empty += 1;
-        }
+        assert!(
+            !output.is_empty(),
+            "random mutation {i} produced empty output"
+        );
     }
-    // Most mutations should produce non-empty output (some hit empty PREAMBLE rule)
-    assert!(non_empty > 50, "only {non_empty}/100 mutations were non-empty");
 }
 
 #[test]

--- a/scaffold/src/scaffold/executor.py
+++ b/scaffold/src/scaffold/executor.py
@@ -177,7 +177,7 @@ def run_gen_sample(depth: int = 15, *, prefix_only: bool = True) -> str:
             Default True for the scaffold pipeline where golden suffixes
             are appended separately.
     """
-    cmd = ["cargo", "run", "--bin", "gen_sample", "--"]
+    cmd = ["cargo", "+nightly", "run", "--bin", "gen_sample", "--"]
     if prefix_only:
         cmd.append("--prefix-only")
     cmd.append(str(depth))


### PR DESCRIPTION
## Status: Work in Progress - Needs Discussion

This PR adds coverage tracking for grammar rules, but **may be the wrong approach**.

### What This Does
- Tracks which grammar rules produce compiling code
- Reports hottest/coldest rules based on success rates
- Lays groundwork for adaptive fuzzing

### The Problem
With only **0.5% compile rate** (16/3227), we have very sparse positive signal. Coverage-guided fuzzing works best with dense feedback.

### Better Approach (Proposed)
Instead of tracking rule coverage on mostly-failures:
1. Take the ~16 successful prefixes from a batch
2. Feed them to Opus with the current grammar
3. Ask: "What patterns work? What rules should we add/remove/modify?"
4. Much higher signal-to-noise ratio

### Discussion Needed
Should we:
- A) Keep this coverage approach and refine it
- B) Pivot to LLM-guided grammar refinement
- C) Hybrid: use coverage to identify successes, then LLM to analyze

@maxvonhippel please review and advise

-claude